### PR TITLE
Add a tarball cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
 # ungit
 
 Fetch the content of a forge's repository at a given reference into a local
-directory. By default, the content of the target directory will be wiped before
-copying the snapshot. [`ungit`](./ungit.sh) uses the various forge APIs, thus
+directory. [`ungit`](./ungit.sh) uses the various forge APIs, thus
 entirely bypasses `git`. You will get a snapshot of the repository at that
 reference, with no history. In most cases, this is much quicker than cloning the
-repository. `ungit` does not work for private repositories.
+repository.
 
-Read [here](#highlights) for a more detailed list of `ungit`'s features, or jump
-straight to the [examples](#examples).
+Read further down a more detailed list of `ungit`'s [features](#highlights) and
+[limitations](#limitations), or jump straight to the [examples](#examples).
 
 ## Examples
 
@@ -60,17 +59,32 @@ and will be able to download content as long as `curl` (preferred) or `wget`
 
 ## Highlights
 
-+ Takes either the full URL to a repository, or its owner/tag as a first
-  parameter. In the second case, the URL is constructed out of the value of the
-  `-t` option -- `github` by default.
++ Takes either the full URL to a repository, or its owner/name as a first
+  parameter. When only an owner/name is provided, the URL is constructed out of
+  the value of the `-t` option -- `github` by default.
++ Keeps a cache of downloaded tarballs under a directory called `ungit` in the
+  [XDG] cache directory. Cached tarballs are reused if possible, unless the
+  `-ff` option is provided (yes: twice the `-f` option!).
++ Will not overwrite the content of the target directory if it already exists,
+  unless the `-f` option is provided.
 + When APIs provide a way to make the difference, the search order for the
-  reference is branch name, tag name, commit reference.
-+ Wipes the content of the target directory, unless the `UNGIT_KEEP` variable is
-  set to `1`. Since `ungit` is about obtaining snapshots of target repositories,
-  the default prevents mixing snapshots.
+  reference is: branch name, tag name, commit reference.
++ When `-f`is provided, wipes the content of the target directory, unless the
+  `UNGIT_KEEP` variable is set to `1`. Since `ungit` is about obtaining
+  snapshots of target repositories, the (good) default prevents mixing several
+  snapshots into the same target directory.
 + `-p` can prevent the target directory to be modified by forcing all files and
-  sub-directories to be read-only. This can prevent headless modification of the
+  sub-directories to be read-only. This can prevent heedless modification of the
   snapshots.
+
+  [XDG]: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+
+## Limitations
+
++ `ungit` does not work for private repositories.
++ If the target repository contains [submodules], the content of these
+  submodules will not be part of the downloaded tarball, nor the directory
+  snapshot.
 
 ## Why?
 
@@ -80,6 +94,7 @@ There are a number of scenarios where this can be useful:
   comfort of your favorite editor.
 + When you want to use neither [submodules], nor [subtree], but still want to
   use (and maintain over time) another project's tree within yours.
++ `ungit` implements a rudimentary package manager.
 + It was fun to write and only took a few hours.
 
   [submodules]: https://git-scm.com/book/en/v2/Git-Tools-Submodules
@@ -88,10 +103,6 @@ There are a number of scenarios where this can be useful:
 ## Ideas
 
 + Implement a github action on top.
-+ Add a local cache (XDG aware) so as to keep tarballs and be able to revert
-  from them. Add a "local" conduit in addition to the download_ functions to use
-  the local tarballs. Make sure cache files are unique (per forge, per repo, pre
-  ref).
 + Add a git mode. When inside a git directory, create a .ungit file with known
   projects added at the root of the git tree. When run again, with a different
   ref, the existing "installation" will be changed. Also add an upgrade mode to


### PR DESCRIPTION
Add a cache of downloaded tarballs. When present in the cache, the tarball will be used instead of downloading.