### PR TITLE
Resolve main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,12 @@ implementation script. For an exact list of inputs, consult the
 + When run from within a `git` repository, will automatically use a file called
   `.unforge` at the root of the repository as an index when adding the first time
   -- and unless specified otherwise.
++ When run from within a `git` repository, the `main` and `master` branches will
+  be resolved to their current reference in the `.unforge` index. This freezes
+  the imported code at the current moment in time and avoids problems when
+  updating later. The list of branches to resolve can be changed through the
+  option `-r`. 
++ Automatically detects the default branch of github and gitlab projects.
 + `unforge` will automatically climb up the hierarchy starting from the
   destination directory to look for the `.unforge` index file when adding,
   installing or deleting. This means that while keeping the `.unforge` index

--- a/action.yml
+++ b/action.yml
@@ -68,5 +68,6 @@ runs:
         "${{ github.action_path }}/unforge.sh" \
           -c '' \
           -f \
+          -i '-' \
           -vv \
           add "$repo" "$target"

--- a/unforge.sh
+++ b/unforge.sh
@@ -173,12 +173,10 @@ download() {
   fi
 }
 
+# Understandable string operations...
 unquote() { sed -e 's/^"//' -e 's/"$//'; }
 quoted_string_eol() { grep -sEo -e '"[^"]+"$'; }
-
-json_string_value() {
-  grep -sEo "\"$1\"\\s*:\\s*\"[^\"]+\"" | quoted_string_eol | unquote
-}
+json_string_value() { grep -sEo "\"$1\"\\s*:\\s*\"[^\"]+\"" | quoted_string_eol | unquote; }
 
 # Call download as per the argument and verify that the downloaded file is a
 # gzip file. If not, remove it. Return an error unless there is a (downloaded)
@@ -196,6 +194,7 @@ download_gz() {
   fi
 }
 
+
 default_github_branch() {
   if [ -n "$UNFORGE_TOKEN" ]; then
     # Add api. in front of the domain name and /repos/ in the path
@@ -209,6 +208,7 @@ default_github_branch() {
       head -n 1
   fi
 }
+
 
 resolve_github_branch() {
   if [ -n "$UNFORGE_TOKEN" ]; then
@@ -254,9 +254,9 @@ download_github_archive() {
   fi
 }
 
+
 default_gitlab_branch() {
   if [ -n "$UNFORGE_TOKEN" ]; then
-    ### TODO: fix this against API doc
     # Extract the repository name from the URL and the root of the domain.
     _repo=$(printf %s\\n "$REPO_URL" | sed -E 's~https://([[:alnum:].:]+)/(.*)~\2~')
     DW_ROOT=$(printf %s\\n "$REPO_URL" | sed -E 's~https://([[:alnum:].:]+)/(.*)~https://\1/~')

--- a/unforge.sh
+++ b/unforge.sh
@@ -20,8 +20,8 @@ UNFORGE_VERBOSE=${UNFORGE_VERBOSE:-0}
 # github.
 UNFORGE_TYPE=${UNFORGE_TYPE:-}
 
-# Default reference to use when none is specified.
-UNFORGE_DEFAULT_REF=${UNFORGE_DEFAULT_REF:-"main"}
+# Default reference to use when none is specified. Empty (default)
+UNFORGE_DEFAULT_REF=${UNFORGE_DEFAULT_REF:-""}
 
 # Branches for which we resolve to current reference when in git mode
 UNFORGE_GIT_RESOLVE=${UNFORGE_GIT_RESOLVE:-"$UNFORGE_DEFAULT_REF master"}
@@ -173,6 +173,12 @@ download() {
   fi
 }
 
+json_string_value() {
+  grep -sEo "\"$1\"\\s*:\\s*\"[^\"]+\"" |
+    grep -sEo -e '"[^"]+"$' |
+    sed -e 's/^"//' -e 's/"$//'
+}
+
 # Call download as per the argument and verify that the downloaded file is a
 # gzip file. If not, remove it. Return an error unless there is a (downloaded)
 # gzip file.
@@ -189,6 +195,20 @@ download_gz() {
   fi
 }
 
+default_github_branch() {
+  if [ -n "$UNFORGE_TOKEN" ]; then
+    # Add api. in front of the domain name and /repos/ in the path
+    DW_ROOT=$(printf %s\\n "$REPO_URL" | sed -E 's~https://([[:alnum:].]+)/~https://api.\1/repos/~')
+    curl -sSL "${DW_ROOT%/}/branches" --header "Authorization: Bearer $UNFORGE_TOKEN" |
+      json_string_value "name" |
+      head -n 1
+  else
+    curl -sSL "${REPO_URL%/}/branches" |
+      json_string_value "name" |
+      head -n 1
+  fi
+}
+
 resolve_github_branch() {
   if [ -n "$UNFORGE_TOKEN" ]; then
     # Add api. in front of the domain name and /repos/ in the path
@@ -196,7 +216,7 @@ resolve_github_branch() {
     curl -sSL "${DW_ROOT%/}/commits?sha=${REPO_REF}" --header "Authorization: Bearer $UNFORGE_TOKEN" |
       grep -sEo 'commits/[0-9a-f]{40}' |
       grep -sEo '[0-9a-f]{40}' |
-      head -n 1 ||true
+      head -n 1
   else
     curl -sSL "${REPO_URL%/}/commits/${REPO_REF}/" |
       grep -sEo 'commit/[0-9a-f]{40}' |
@@ -233,6 +253,7 @@ download_github_archive() {
   fi
 }
 
+
 resolve_gitlab_branch() {
   if [ -n "$UNFORGE_TOKEN" ]; then
     # Extract the repository name from the URL and the root of the domain.
@@ -241,12 +262,12 @@ resolve_gitlab_branch() {
     curl -sSL "${DW_ROOT%/}/api/v4/projects/$(urlencode "$_repo")/repository/commits?ref_name=${REPO_REF}" --header "PRIVATE-TOKEN: $UNFORGE_TOKEN" |
       grep -sEo 'commit/[0-9a-f]{40}' |
       grep -sEo '[0-9a-f]{40}' |
-      head -n 1 ||true
+      head -n 1
   else
     curl -sSL "${REPO_URL%/}/-/commits/${REPO_REF}/" |
       grep -sEo 'tree/[0-9a-f]{40}' |
       grep -sEo '[0-9a-f]{40}' |
-      head -n 1 ||true
+      head -n 1
   fi
 }
 
@@ -516,10 +537,29 @@ cmd_add() {
   fi
   shift
 
+  # Decide the repository type when none is specified, detect from the URL.
+  # Enforce the ones we recognise.
+  if [ -z "$UNFORGE_TYPE" ]; then
+    if printf %s\\n "$REPO_URL" | grep -q 'github\.com'; then
+      UNFORGE_TYPE=github
+    elif printf %s\\n "$REPO_URL" | grep -q 'gitlab\.com'; then
+      UNFORGE_TYPE=gitlab
+    else
+      error "Unsupported repository type: $REPO_URL"
+    fi
+  elif ! printf %s\\n "$UNFORGE_TYPE" | grep -qE 'git(hub|lab)'; then
+    error "Unsupported repository type: $UNFORGE_TYPE"
+  fi
+
   # Extract the tag, branch or commit reference as being everything after the @
   REPO_REF=$(printf %s\\n "$REPO_URL" | grep -oE '@.*$' | cut -c 2-)
   if [ -z "$REPO_REF" ]; then
-    REPO_REF=$UNFORGE_DEFAULT_REF
+    if [ -z "$UNFORGE_DEFAULT_REF" ]; then
+      debug "Detecting default branch for $REPO_URL"
+      REPO_REF=$(default_${UNFORGE_TYPE}_branch)
+      verbose "Detected default branch of $REPO_URL to be: $REPO_REF"
+      UNFORGE_DEFAULT_REF=$REPO_REF
+    fi
   else
     REPO_URL=$(printf %s\\n "$REPO_URL" | sed 's/@.*$//')
   fi
@@ -536,29 +576,17 @@ cmd_add() {
   # Lookup for a .git directory to be able to turn on "git mode"
   index_detect "$(dirname "$DESTDIR")"
 
-  # Decide the repository type when none is specified, detect from the URL.
-  # Enforce the ones we recognise.
-  if [ -z "$UNFORGE_TYPE" ]; then
-    if printf %s\\n "$REPO_URL" | grep -q 'github\.com'; then
-      UNFORGE_TYPE=github
-    elif printf %s\\n "$REPO_URL" | grep -q 'gitlab\.com'; then
-      UNFORGE_TYPE=gitlab
-    else
-      error "Unsupported repository type: $REPO_URL"
-    fi
-  elif ! printf %s\\n "$UNFORGE_TYPE" | grep -qE 'git(hub|lab)'; then
-    error "Unsupported repository type: $UNFORGE_TYPE"
-  fi
-
   # When inside a git repo, if branch is main, resolve it to its current
   # reference.
   if [ -n "$UNFORGE_INDEX" ]; then
     if printf %s\\n "$UNFORGE_INDEX" | grep -Fq "$GITROOT"; then
       if printf %s\\n "$UNFORGE_GIT_RESOLVE" | grep -Fq "$REPO_REF"; then
+        debug "Resolving $REPO_REF branch at $UNFORGE_TYPE"
         ref=$(resolve_${UNFORGE_TYPE}_branch "$REPO_REF")
         if [ -z "$ref" ]; then
           warning "Could not resolve $REPO_REF to current commit at $REPO_URL"
         else
+          verbose "Pinpointed ($UNFORGE_TYPE) $REPO_REF to $ref"
           REPO_REF=$ref
         fi
       fi

--- a/unforge.sh
+++ b/unforge.sh
@@ -21,7 +21,10 @@ UNFORGE_VERBOSE=${UNFORGE_VERBOSE:-0}
 UNFORGE_TYPE=${UNFORGE_TYPE:-}
 
 # Default reference to use when none is specified.
-UNFORGE_DEFAULT_REF=${UNFORGE_DEFAULT_REF:-main}
+UNFORGE_DEFAULT_REF=${UNFORGE_DEFAULT_REF:-"main"}
+
+# Branches for which we resolve to current reference when in git mode
+UNFORGE_GIT_RESOLVE=${UNFORGE_GIT_RESOLVE:-"$UNFORGE_DEFAULT_REF master"}
 
 # When >=1 Force overwriting of existing files and directories, when >=2 force
 # redownload of tarball even if in cache.
@@ -186,6 +189,23 @@ download_gz() {
   fi
 }
 
+resolve_github_branch() {
+  if [ -n "$UNFORGE_TOKEN" ]; then
+    # Add api. in front of the domain name and /repos/ in the path
+    DW_ROOT=$(printf %s\\n "$REPO_URL" | sed -E 's~https://([[:alnum:].]+)/~https://api.\1/repos/~')
+    curl -sSL "${DW_ROOT%/}/commits?sha=${REPO_REF}" --header "Authorization: Bearer $UNFORGE_TOKEN" |
+      grep -sEo 'commits/[0-9a-f]{40}' |
+      grep -sEo '[0-9a-f]{40}' |
+      head -n 1 ||true
+  else
+    curl -sSL "${REPO_URL%/}/commits/${REPO_REF}/" |
+      grep -sEo 'commit/[0-9a-f]{40}' |
+      grep -sEo '[0-9a-f]{40}' |
+      head -n 1
+  fi
+}
+
+
 # Download the $REPO_URL at the $REPO_REF reference from GitHub. When a token is
 # provided, rewrite the URL to point to the API URL and passed the token.
 download_github_archive() {
@@ -199,6 +219,8 @@ download_github_archive() {
     # from the various possible locations.
     if printf %s\\n "$REPO_REF" | grep -q '^refs/'; then
       download_gz "${REPO_URL%/}/archive/${REPO_REF}.tar.gz" "${1:-}"
+    elif printf %s\\n "$REPO_REF" | grep -qE '^[0-9a-f]{40}'; then
+      download_gz "${REPO_URL%/}/archive/${REPO_REF}.tar.gz" "${1:-}"
     else
       # Consider the reference to be a banch name first, then a tag name, then a
       # pull request, then a commit hash. Note: does not perform any check on
@@ -210,6 +232,24 @@ download_github_archive() {
     fi
   fi
 }
+
+resolve_gitlab_branch() {
+  if [ -n "$UNFORGE_TOKEN" ]; then
+    # Extract the repository name from the URL and the root of the domain.
+    _repo=$(printf %s\\n "$REPO_URL" | sed -E 's~https://([[:alnum:].:]+)/(.*)~\2~')
+    DW_ROOT=$(printf %s\\n "$REPO_URL" | sed -E 's~https://([[:alnum:].:]+)/(.*)~https://\1/~')
+    curl -sSL "${DW_ROOT%/}/api/v4/projects/$(urlencode "$_repo")/repository/commits?ref_name=${REPO_REF}" --header "PRIVATE-TOKEN: $UNFORGE_TOKEN" |
+      grep -sEo 'commit/[0-9a-f]{40}' |
+      grep -sEo '[0-9a-f]{40}' |
+      head -n 1 ||true
+  else
+    curl -sSL "${REPO_URL%/}/-/commits/${REPO_REF}/" |
+      grep -sEo 'tree/[0-9a-f]{40}' |
+      grep -sEo '[0-9a-f]{40}' |
+      head -n 1 ||true
+  fi
+}
+
 
 # Download the $REPO_URL at the $REPO_REF reference from GitLab. Rely on
 # GitLab's algorithm for resolving the reference to its real type: banch name,
@@ -285,6 +325,16 @@ relpath() {
   printf %s\\n "${b}${d#"$s"/}"
 }
 
+git_detect() {
+  GITROOT=""
+  GITDIR=$(climb_and_find .git "$1" | head -n 1)
+  if [ -z "$GITDIR" ]; then
+    verbose "Could not find a .git directory in $1"
+  else
+    GITROOT=$(dirname "$GITDIR")
+  fi
+}
+
 # Look up the hierarchy of $1 for a .git directory to be able to turn on "git
 # mode". Set the $GITROOT variable to the root location of the git repository
 # this is called from and adapt the UNFORGE_INDEX if none was specified.
@@ -298,21 +348,17 @@ index_detect() {
   elif [ -z "$UNFORGE_INDEX" ]; then
     UNFORGE_INDEX=$(climb_and_find .unforge "$1" | head -n 1)
     if [ -n "$UNFORGE_INDEX" ]; then
+      git_detect "$(dirname "$UNFORGE_INDEX")"
       verbose "Using $UNFORGE_INDEX as index file"
     else
-      GITDIR=$(climb_and_find .git "$1" | head -n 1)
-      if [ -z "$GITDIR" ]; then
-        verbose "Could not find a .git directory in $1"
-        GITROOT=""
-      else
-        GITROOT=$(dirname "$GITDIR")
-      fi
-
+      git_detect "$1"
       if [ -n "$GITROOT" ]; then
         UNFORGE_INDEX=${GITROOT}/.unforge
         verbose "Using $UNFORGE_INDEX as index file"
       fi
     fi
+  else
+    git_detect "$(dirname "$UNFORGE_INDEX")"
   fi
 
   # Automatically turn target directory protection when applicable. Down from
@@ -490,7 +536,8 @@ cmd_add() {
   # Lookup for a .git directory to be able to turn on "git mode"
   index_detect "$(dirname "$DESTDIR")"
 
-  # Decide the repository type when none is specified, detect from the URL
+  # Decide the repository type when none is specified, detect from the URL.
+  # Enforce the ones we recognise.
   if [ -z "$UNFORGE_TYPE" ]; then
     if printf %s\\n "$REPO_URL" | grep -q 'github\.com'; then
       UNFORGE_TYPE=github
@@ -498,6 +545,23 @@ cmd_add() {
       UNFORGE_TYPE=gitlab
     else
       error "Unsupported repository type: $REPO_URL"
+    fi
+  elif ! printf %s\\n "$UNFORGE_TYPE" | grep -qE 'git(hub|lab)'; then
+    error "Unsupported repository type: $UNFORGE_TYPE"
+  fi
+
+  # When inside a git repo, if branch is main, resolve it to its current
+  # reference.
+  if [ -n "$UNFORGE_INDEX" ]; then
+    if printf %s\\n "$UNFORGE_INDEX" | grep -Fq "$GITROOT"; then
+      if printf %s\\n "$UNFORGE_GIT_RESOLVE" | grep -Fq "$REPO_REF"; then
+        ref=$(resolve_${UNFORGE_TYPE}_branch "$REPO_REF")
+        if [ -z "$ref" ]; then
+          warning "Could not resolve $REPO_REF to current commit at $REPO_URL"
+        else
+          REPO_REF=$ref
+        fi
+      fi
     fi
   fi
 


### PR DESCRIPTION
Automatically resolve the main or master branches to their current sha references, when working in `git` mode. Also this will automatically detect the default branch of the remote project.